### PR TITLE
Fix box save workflow error handling

### DIFF
--- a/src/lib/save-workflow.ts
+++ b/src/lib/save-workflow.ts
@@ -1,0 +1,122 @@
+export type SaveOutcome = 'noop' | 'success' | 'partial' | 'failure';
+
+export type SaveFailure = {
+	kind: 'contents' | 'upload' | 'delete';
+	message: string;
+};
+
+export type SaveWorkflowResult = {
+	outcome: SaveOutcome;
+	attempted: number;
+	succeeded: number;
+	contentsSaved: boolean;
+	remainingUploads: string[];
+	remainingDeletions: string[];
+	failures: SaveFailure[];
+};
+
+type SaveWorkflowInput = {
+	id: string;
+	contents: string;
+	contentsChanged: boolean;
+	newPhotos: string[];
+	delPhotos: string[];
+	fetch?: typeof globalThis.fetch;
+};
+
+type MutationResult = { ok: true } | { ok: false; message: string };
+
+const responseError = async (response: Response) => {
+	let detail = '';
+
+	try {
+		const body = await response.clone().json();
+		detail = body?.details || body?.error || body?.message || '';
+	} catch {
+		try {
+			detail = (await response.text()).trim();
+		} catch {
+			// A status is still useful when the response body cannot be read.
+		}
+	}
+
+	return detail ? `${response.status}: ${detail}` : `HTTP ${response.status}`;
+};
+
+const mutate = async (
+	fetchImpl: typeof globalThis.fetch,
+	endpoint: string,
+	payload: Record<string, string>
+): Promise<MutationResult> => {
+	try {
+		const response = await fetchImpl(endpoint, {
+			method: 'PATCH',
+			body: JSON.stringify(payload),
+			headers: { 'content-type': 'application/json' }
+		});
+
+		return response.ok ? { ok: true } : { ok: false, message: await responseError(response) };
+	} catch (error) {
+		return {
+			ok: false,
+			message: error instanceof Error ? error.message : 'Network request failed'
+		};
+	}
+};
+
+export const saveBoxChanges = async ({
+	id,
+	contents,
+	contentsChanged,
+	newPhotos,
+	delPhotos,
+	fetch: fetchImpl = globalThis.fetch
+}: SaveWorkflowInput): Promise<SaveWorkflowResult> => {
+	const contentRequest = contentsChanged
+		? mutate(fetchImpl, '/api/saveContent', { id, contents })
+		: undefined;
+	const uploadRequests = newPhotos.map((base64) =>
+		mutate(fetchImpl, '/api/saveImage', { id, base64 })
+	);
+	const deletionRequests = delPhotos.map((base64) =>
+		mutate(fetchImpl, '/api/delImage', { id, base64 })
+	);
+
+	const [contentResult, uploadResults, deletionResults] = await Promise.all([
+		contentRequest,
+		Promise.all(uploadRequests),
+		Promise.all(deletionRequests)
+	]);
+	const failures: SaveFailure[] = [];
+
+	if (contentResult && !contentResult.ok) {
+		failures.push({ kind: 'contents', message: contentResult.message });
+	}
+	uploadResults.forEach((result) => {
+		if (!result.ok) failures.push({ kind: 'upload', message: result.message });
+	});
+	deletionResults.forEach((result) => {
+		if (!result.ok) failures.push({ kind: 'delete', message: result.message });
+	});
+
+	const attempted = Number(contentsChanged) + uploadResults.length + deletionResults.length;
+	const succeeded = attempted - failures.length;
+	const outcome: SaveOutcome =
+		attempted === 0
+			? 'noop'
+			: succeeded === attempted
+				? 'success'
+				: succeeded === 0
+					? 'failure'
+					: 'partial';
+
+	return {
+		outcome,
+		attempted,
+		succeeded,
+		contentsSaved: contentResult?.ok === true,
+		remainingUploads: newPhotos.filter((_, index) => !uploadResults[index]?.ok),
+		remainingDeletions: delPhotos.filter((_, index) => !deletionResults[index]?.ok),
+		failures
+	};
+};

--- a/src/routes/api/saveContent/+server.ts
+++ b/src/routes/api/saveContent/+server.ts
@@ -6,7 +6,7 @@ import type { RequestHandler } from './$types';
 export const PATCH: RequestHandler = async ({ request }) => {
 	const { id, contents } = await request.json();
 
-	if (!id || !contents) {
+	if (typeof id !== 'string' || id.length === 0 || typeof contents !== 'string') {
 		return json({ error: 'Invalid request' }, { status: 400 });
 	}
 	try {

--- a/src/routes/box/[slug]/+page.svelte
+++ b/src/routes/box/[slug]/+page.svelte
@@ -23,6 +23,7 @@
 	import { MasonryGrid } from '@egjs/svelte-grid';
 
 	import type { toastData, toastType } from '$lib/types/types';
+	import { saveBoxChanges } from '$lib/save-workflow';
 
 	/** @type {import('./$types').PageData} */
 	export let data;
@@ -65,92 +66,39 @@
 			return;
 		}
 
-		// TODO: fix error handling
-		let contentsSave = false;
-		let imgSave: number | null = 0;
-		let imgDel: number | null = 0;
-		let error;
 		saving = true;
-		if (initContents != contents) {
-			const res = await fetch('/api/saveContent', {
-				method: 'PATCH',
-				body: JSON.stringify({ id, contents }),
-				headers: {
-					'content-type': 'application/json'
-				}
+		try {
+			const result = await saveBoxChanges({
+				id,
+				contents,
+				contentsChanged: initContents !== contents,
+				newPhotos,
+				delPhotos
 			});
-			if (!res.ok) {
+
+			if (result.contentsSaved) initContents = contents;
+			newPhotos = result.remainingUploads;
+			delPhotos = result.remainingDeletions;
+
+			if (result.outcome === 'success') {
+				addToast('success', 'Success!', 'Changes have been saved.');
+			} else if (result.outcome === 'partial') {
+				addToast(
+					'warning',
+					'Some changes were not saved.',
+					`${result.succeeded} of ${result.attempted} changes saved. ${result.failures.map(({ message }) => message).join('; ')}`
+				);
+			} else if (result.outcome === 'failure') {
 				addToast(
 					'error',
-					'Oops, something went wrong.',
-					`An error occurred, status: ${res.status}.`
+					'Changes were not saved.',
+					result.failures.map(({ message }) => message).join('; ')
 				);
 			} else {
-				contentsSave = true;
-				initContents = contents;
+				addToast('info', 'No changes to save.', 'Everything is already up to date.');
 			}
-		}
-		if (newPhotos.length > 0) imgSave = await saveImgs();
-		if (delPhotos.length > 0) imgDel = await saveDelImg();
-		if (contentsSave || imgSave !== null || imgDel !== null) {
-			addToast('success', 'Success!', 'Changes have been saved.');
-		} else {
-			addToast('error', 'Oops, something went wrong.', `An error occurred, status: ${error}.`);
-		}
-		saving = false;
-	};
-
-	const uploadImg = async (base64: string) => {
-		const res = await fetch('/api/saveImage', {
-			method: 'PATCH',
-			body: JSON.stringify({ id, base64 }),
-			headers: {
-				'content-type': 'application/json'
-			}
-		});
-		return res.ok;
-	};
-	const saveImgs = async () => {
-		if (newPhotos.length == 0) return 0;
-
-		let values = await Promise.all(newPhotos.map((photo) => uploadImg(photo)));
-		newPhotos = [];
-
-		if (values.length === 0) {
-			return 0;
-		}
-
-		if (values.every((value) => value === true)) {
-			return values.length;
-		} else {
-			return null;
-		}
-	};
-
-	const unUploadImg = async (base64: string) => {
-		const res = await fetch('/api/delImage', {
-			method: 'PATCH',
-			body: JSON.stringify({ id, base64 }),
-			headers: {
-				'content-type': 'application/json'
-			}
-		});
-		return res.ok;
-	};
-	const saveDelImg = async () => {
-		if (delPhotos.length == 0) return 0;
-
-		let values = await Promise.all(delPhotos.map((photo) => unUploadImg(photo)));
-		delPhotos = [];
-
-		if (values.length === 0) {
-			return 0;
-		}
-
-		if (values.every((value) => value === true)) {
-			return values.length;
-		} else {
-			return null;
+		} finally {
+			saving = false;
 		}
 	};
 
@@ -201,14 +149,15 @@
 		}
 	};
 	const splicePhoto = (index: number) => {
-		let isNewPhoto = false;
-		newPhotos = newPhotos.filter((photo) => {
-			photo !== photos[index];
-			isNewPhoto = true;
-		});
-		if (!isNewPhoto) delPhotos = [...delPhotos, photos[index]];
-		photos.splice(index, 1);
-		photos = [...photos];
+		const removedPhoto = photos[index];
+		const newPhotoIndex = newPhotos.indexOf(removedPhoto);
+
+		if (newPhotoIndex >= 0) {
+			newPhotos = newPhotos.filter((_, photoIndex) => photoIndex !== newPhotoIndex);
+		} else if (!delPhotos.includes(removedPhoto)) {
+			delPhotos = [...delPhotos, removedPhoto];
+		}
+		photos = photos.filter((_: string, photoIndex: number) => photoIndex !== index);
 	};
 	const newBox = async () => {
 		if (data.demoMode) {

--- a/tests/save-workflow.test.js
+++ b/tests/save-workflow.test.js
@@ -1,0 +1,120 @@
+// @ts-nocheck -- Bun executes this JavaScript test; TypeScript checks the imported source.
+import { describe, expect, test } from 'bun:test';
+import { saveBoxChanges } from '../src/lib/save-workflow.ts';
+
+const jsonResponse = (body, status = 200) =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: { 'content-type': 'application/json' }
+	});
+
+describe('saveBoxChanges', () => {
+	test('reports a successful save and empties completed image queues', async () => {
+		const requests = [];
+		const fetch = async (endpoint, options) => {
+			requests.push([endpoint, JSON.parse(options.body)]);
+			return jsonResponse({ status: 'ok' });
+		};
+
+		const result = await saveBoxChanges({
+			id: 'garage',
+			contents: 'tools',
+			contentsChanged: true,
+			newPhotos: ['new-image'],
+			delPhotos: ['old-image'],
+			fetch
+		});
+
+		expect(result).toMatchObject({
+			outcome: 'success',
+			attempted: 3,
+			succeeded: 3,
+			contentsSaved: true,
+			remainingUploads: [],
+			remainingDeletions: [],
+			failures: []
+		});
+		expect(requests.map(([endpoint]) => endpoint).sort()).toEqual([
+			'/api/delImage',
+			'/api/saveContent',
+			'/api/saveImage'
+		]);
+	});
+
+	test('reports total failure with server and network error details', async () => {
+		const fetch = async (endpoint) => {
+			if (endpoint === '/api/saveContent') {
+				return jsonResponse({ error: 'Box not found' }, 404);
+			}
+			throw new Error('connection lost');
+		};
+
+		const result = await saveBoxChanges({
+			id: 'missing',
+			contents: '',
+			contentsChanged: true,
+			newPhotos: ['new-image'],
+			delPhotos: [],
+			fetch
+		});
+
+		expect(result.outcome).toBe('failure');
+		expect(result.succeeded).toBe(0);
+		expect(result.contentsSaved).toBe(false);
+		expect(result.remainingUploads).toEqual(['new-image']);
+		expect(result.failures.map(({ message }) => message)).toEqual([
+			'404: Box not found',
+			'connection lost'
+		]);
+	});
+
+	test('reports partial success and retains only failed operations for retry', async () => {
+		const fetch = async (endpoint, options) => {
+			const { base64 } = JSON.parse(options.body);
+			if (endpoint === '/api/saveImage' && base64 === 'bad-upload') {
+				return jsonResponse({ details: 'invalid image' }, 500);
+			}
+			if (endpoint === '/api/delImage' && base64 === 'bad-delete') {
+				return new Response('storage unavailable', { status: 503 });
+			}
+			return jsonResponse({ status: 'ok' });
+		};
+
+		const result = await saveBoxChanges({
+			id: 'garage',
+			contents: 'unchanged',
+			contentsChanged: false,
+			newPhotos: ['good-upload', 'bad-upload'],
+			delPhotos: ['bad-delete', 'good-delete'],
+			fetch
+		});
+
+		expect(result.outcome).toBe('partial');
+		expect(result.succeeded).toBe(2);
+		expect(result.remainingUploads).toEqual(['bad-upload']);
+		expect(result.remainingDeletions).toEqual(['bad-delete']);
+		expect(result.failures.map(({ message }) => message)).toEqual([
+			'500: invalid image',
+			'503: storage unavailable'
+		]);
+	});
+
+	test('does not issue a request for a no-op save', async () => {
+		let requestCount = 0;
+		const result = await saveBoxChanges({
+			id: 'garage',
+			contents: 'unchanged',
+			contentsChanged: false,
+			newPhotos: [],
+			delPhotos: [],
+			fetch: async () => {
+				requestCount += 1;
+				return jsonResponse({ status: 'ok' });
+			}
+		});
+
+		expect(result.outcome).toBe('noop');
+		expect(result.attempted).toBe(0);
+		expect(requestCount).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- report accurate success, partial failure, failure, and no-op save outcomes
- retain failed image operations for retry and always clear the saving state
- fix photo-removal bookkeeping and allow empty box contents
- add save workflow coverage for success, failure, partial failure, and no-op cases

## Validation
- `bun test` (13 passed)
- `bun run check` (0 errors, 0 warnings)
- `bun run build`
